### PR TITLE
Add the docker "repository", not just the account

### DIFF
--- a/site/_docs/docker_images.md
+++ b/site/_docs/docker_images.md
@@ -43,7 +43,7 @@ jar (which contains all the necessary dependencies of the Avatica server). This 
 image is not directly useful for end users; it is useful for those who want to use Avatica
 with a database of their choosing.
 
-This Docker image is deployed to the [Apache Dockerhub account](https://hub.docker.com/r/apache/)
+This Docker image is deployed to the [Apache Dockerhub account](https://hub.docker.com/r/apache/calcite-avatica)
 and is updated for each release of Avatica.
 
 ### Database-specific Docker Images

--- a/site/_posts/2017-05-30-release-1.10.0.md
+++ b/site/_posts/2017-05-30-release-1.10.0.md
@@ -30,7 +30,7 @@ Apache Calcite Avatica 1.10.0 adds support for JDBC Array data,
 Docker, and JDK 9.
 
 From this release onwards, Docker images for Avatica Server are
-published to [Dockerhub](https://hub.docker.com/r/apache/).  These
+published to [Dockerhub](https://hub.docker.com/r/apache/calcite-avatica).  These
 make Avatica is [easier than ever to run](../docs/docker_images.md).
 
 As the Calcite and Avatica projects become


### PR DESCRIPTION
I wrote the documentation before getting the account set up
by INFRA. No reason to not link the actual site.